### PR TITLE
feat(markdown): Enable raw HTML rendering for embedded images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -61,6 +61,18 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'ibb.co',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'i.ibb.co',
+        port: '',
+        pathname: '/**',
+      },
     ],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "arkegu-portfolio",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "^5.7.1",
         "@vercel/blob": "^0.15.1",
@@ -20,8 +21,9 @@
         "react-dom": "^18",
         "react-icons": "^4.12.0",
         "react-intersection-observer": "^9.5.3",
-        "react-markdown": "^9.0.1",
-        "remark-gfm": "^4.0.0",
+        "react-markdown": "^9.1.0",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1",
         "typed.js": "^2.1.0"
       },
       "devDependencies": {
@@ -3760,6 +3762,64 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -3787,6 +3847,35 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
+      "integrity": "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5/node_modules/property-information": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
+      "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -3794,6 +3883,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3820,6 +3926,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -6758,6 +6874,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -8274,6 +8405,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -8311,6 +8456,16 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -58,8 +58,9 @@
     "react-dom": "^18",
     "react-icons": "^4.12.0",
     "react-intersection-observer": "^9.5.3",
-    "react-markdown": "^9.0.1",
-    "remark-gfm": "^4.0.0",
+    "react-markdown": "^9.1.0",
+    "rehype-raw": "^7.0.0",
+    "remark-gfm": "^4.0.1",
     "typed.js": "^2.1.0"
   },
   "devDependencies": {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import { FiArrowLeft, FiCalendar, FiClock, FiTag, FiShare2, FiTwitter, FiLinkedin, FiFacebook, FiLink, FiGithub, FiMail } from "react-icons/fi";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
 import { prisma } from "@/lib/prisma";
 import { BlogPost, Comment } from "@/types/blog";
 import CommentForm from "@/components/blog/CommentForm";
@@ -272,7 +273,27 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
                 <SocialShare post={post} url={currentUrl} />
               </div>
               <div className="prose prose-gray dark:prose-invert max-w-none">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{post.content}</ReactMarkdown>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeRaw]}
+                  components={{
+                    img: ({ node, ...props }) => {
+                      if (!props.src) return null
+                      return (
+                        <Image
+                          {...props}
+                          src={props.src}
+                          width={700}
+                          height={400}
+                          className="rounded-lg"
+                          alt={props.alt || ''}
+                        />
+                      )
+                    },
+                  }}
+                >
+                  {post.content}
+                </ReactMarkdown>
               </div>
               <AuthorBio />
             </div>

--- a/src/components/admin/DeletePostButton.tsx
+++ b/src/components/admin/DeletePostButton.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import { FiTrash2, FiLoader, FiAlertCircle, FiX } from 'react-icons/fi'
@@ -16,6 +17,11 @@ const DeletePostButton = ({ postId, postTitle, onDelete }: DeletePostButtonProps
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [isClient, setIsClient] = useState(false)
+
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
 
   const handleDelete = async () => {
     if (!postId) return
@@ -70,100 +76,104 @@ const DeletePostButton = ({ postId, postTitle, onDelete }: DeletePostButtonProps
       </button>
 
       {/* Confirmation Dialog */}
-      <AnimatePresence>
-        {showConfirmDialog && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 backdrop-blur-sm"
-            onClick={handleCancel}
-          >
-            <motion.div
-              initial={{ scale: 0.9, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.9, opacity: 0 }}
-              className="bg-gray-900 border border-gray-700 rounded-xl p-6 max-w-md w-full mx-4 shadow-2xl shadow-red-500/10"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {/* Header */}
-              <div className="flex items-center justify-between mb-4">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 bg-red-500/20 rounded-lg border border-red-500/30">
-                    <FiAlertCircle className="w-5 h-5 text-red-400" />
-                  </div>
-                  <h3 className="text-lg font-semibold text-white">Delete Post</h3>
-                </div>
-                <button
-                  onClick={handleCancel}
-                  className="p-1 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-colors"
-                  disabled={isDeleting}
+      {isClient &&
+        createPortal(
+          <AnimatePresence>
+            {showConfirmDialog && (
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 backdrop-blur-sm"
+                onClick={handleCancel}
+              >
+                <motion.div
+                  initial={{ scale: 0.9, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  exit={{ scale: 0.9, opacity: 0 }}
+                  className="bg-gray-900 border border-gray-700 rounded-xl p-6 max-w-md w-full mx-4 shadow-2xl shadow-red-500/10"
+                  onClick={(e) => e.stopPropagation()}
                 >
-                  <FiX className="w-4 h-4" />
-                </button>
-              </div>
-
-              {/* Content */}
-              <div className="mb-6">
-                <p className="text-gray-300 mb-3">
-                  Are you sure you want to delete this post? This action cannot be undone.
-                </p>
-                <div className="p-3 bg-gray-800/50 border border-gray-700/50 rounded-lg">
-                  <p className="text-sm text-gray-400 mb-1">Post Title:</p>
-                  <p className="text-white font-medium truncate" title={postTitle}>
-                    {postTitle}
-                  </p>
-                </div>
-              </div>
-
-              {/* Error Message */}
-              <AnimatePresence>
-                {error && (
-                  <motion.div
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: 'auto' }}
-                    exit={{ opacity: 0, height: 0 }}
-                    className="mb-4 p-3 bg-red-500/10 border border-red-500/30 rounded-lg"
-                  >
-                    <div className="flex items-center gap-2">
-                      <FiAlertCircle className="w-4 h-4 text-red-400 flex-shrink-0" />
-                      <p className="text-red-300 text-sm">{error}</p>
+                  {/* Header */}
+                  <div className="flex items-center justify-between mb-4">
+                    <div className="flex items-center gap-3">
+                      <div className="p-2 bg-red-500/20 rounded-lg border border-red-500/30">
+                        <FiAlertCircle className="w-5 h-5 text-red-400" />
+                      </div>
+                      <h3 className="text-lg font-semibold text-white">Delete Post</h3>
                     </div>
-                  </motion.div>
-                )}
-              </AnimatePresence>
+                    <button
+                      onClick={handleCancel}
+                      className="p-1 text-gray-400 hover:text-white hover:bg-gray-700 rounded-lg transition-colors"
+                      disabled={isDeleting}
+                    >
+                      <FiX className="w-4 h-4" />
+                    </button>
+                  </div>
 
-              {/* Actions */}
-              <div className="flex gap-3">
-                <button
-                  onClick={handleCancel}
-                  className="flex-1 px-4 py-2 text-gray-300 hover:text-white bg-gray-800 hover:bg-gray-700 border border-gray-600 rounded-lg transition-all duration-200"
-                  disabled={isDeleting}
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleDelete}
-                  className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-lg transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-red-500/25"
-                  disabled={isDeleting}
-                >
-                  {isDeleting ? (
-                    <>
-                      <FiLoader className="w-4 h-4 animate-spin" />
-                      Deleting...
-                    </>
-                  ) : (
-                    <>
-                      <FiTrash2 className="w-4 h-4" />
-                      Delete Post
-                    </>
-                  )}
-                </button>
-              </div>
-            </motion.div>
-          </motion.div>
+                  {/* Content */}
+                  <div className="mb-6">
+                    <p className="text-gray-300 mb-3">
+                      Are you sure you want to delete this post? This action cannot be undone.
+                    </p>
+                    <div className="p-3 bg-gray-800/50 border border-gray-700/50 rounded-lg">
+                      <p className="text-sm text-gray-400 mb-1">Post Title:</p>
+                      <p className="text-white font-medium truncate" title={postTitle}>
+                        {postTitle}
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* Error Message */}
+                  <AnimatePresence>
+                    {error && (
+                      <motion.div
+                        initial={{ opacity: 0, height: 0 }}
+                        animate={{ opacity: 1, height: 'auto' }}
+                        exit={{ opacity: 0, height: 0 }}
+                        className="mb-4 p-3 bg-red-500/10 border border-red-500/30 rounded-lg"
+                      >
+                        <div className="flex items-center gap-2">
+                          <FiAlertCircle className="w-4 h-4 text-red-400 flex-shrink-0" />
+                          <p className="text-red-300 text-sm">{error}</p>
+                        </div>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+
+                  {/* Actions */}
+                  <div className="flex gap-3">
+                    <button
+                      onClick={handleCancel}
+                      className="flex-1 px-4 py-2 text-gray-300 hover:text-white bg-gray-800 hover:bg-gray-700 border border-gray-600 rounded-lg transition-all duration-200"
+                      disabled={isDeleting}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={handleDelete}
+                      className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-lg transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-red-500/25"
+                      disabled={isDeleting}
+                    >
+                      {isDeleting ? (
+                        <>
+                          <FiLoader className="w-4 h-4 animate-spin" />
+                          Deleting...
+                        </>
+                      ) : (
+                        <>
+                          <FiTrash2 className="w-4 h-4" />
+                          Delete Post
+                        </>
+                      )}
+                    </button>
+                  </div>
+                </motion.div>
+              </motion.div>
+            )}
+          </AnimatePresence>,
+          document.body
         )}
-      </AnimatePresence>
     </>
   )
 }

--- a/src/components/admin/PostEditor.tsx
+++ b/src/components/admin/PostEditor.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect, useRef } from 'react'
+import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import { 
@@ -17,6 +18,9 @@ import {
   FiLoader,
   FiAlertCircle
 } from 'react-icons/fi'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import rehypeRaw from 'rehype-raw'
 import { generateSlug, generateExcerpt } from '@/lib/blog-utils'
 import type { BlogPost, CreateBlogPostRequest, UpdateBlogPostRequest } from '@/types/blog'
 
@@ -592,20 +596,28 @@ const PostEditor = ({ post, onSave }: PostEditorProps) => {
                 ) : (
                   // Preview
                   <div className="w-full h-[500px] p-4 bg-gray-800/30 border border-gray-600/50 rounded-lg overflow-y-auto">
-                    <div className="prose prose-invert prose-blue max-w-none">
-                      <div
-                        dangerouslySetInnerHTML={{
-                          __html: formData.content
-                            .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-                            .replace(/\*(.*?)\*/g, '<em>$1</em>')
-                            .replace(/`(.*?)`/g, '<code class="px-1 py-0.5 bg-gray-700 rounded text-sm">$1</code>')
-                            .replace(/^### (.*$)/gim, '<h3 class="text-lg font-semibold text-white mt-6 mb-3">$1</h3>')
-                            .replace(/^## (.*$)/gim, '<h2 class="text-xl font-semibold text-white mt-6 mb-4">$1</h2>')
-                            .replace(/^# (.*$)/gim, '<h1 class="text-2xl font-bold text-white mt-6 mb-4">$1</h1>')
-                            .replace(/\n/g, '<br>')
-                        }}
-                      />
-                    </div>
+                    <ReactMarkdown
+                      className="prose prose-invert prose-blue max-w-none"
+                      remarkPlugins={[remarkGfm]}
+                      rehypePlugins={[rehypeRaw]}
+                      components={{
+                        img: ({ node, ...props }) => {
+                          if (!props.src) return null
+                          return (
+                            <Image
+                              {...props}
+                              src={props.src}
+                              width={700}
+                              height={400}
+                              className="rounded-lg"
+                              alt={props.alt || ''}
+                            />
+                          )
+                        },
+                      }}
+                    >
+                      {formData.content}
+                    </ReactMarkdown>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
This commit introduces support for rendering raw HTML within markdown content by adding the `rehype-raw` plugin. This is necessary to display images embedded using `<img>` tags.

To support images hosted on ImgBB, the `ibb.co` and `i.ibb.co` domains have been whitelisted in the `next.config.js` file, allowing Next.js to optimize these external images.

Dependencies `react-markdown` and `remark-gfm` were also updated to their latest versions.